### PR TITLE
Make reign of the unliving unable to proc itself

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1114,7 +1114,10 @@ std::vector<action::Action> Player::onSpellImpactProc(const State& state, const 
                 actions.push_back(buffAction<buff::AshtongueTalisman>());
 
 
-            if (hasTrinket(TRINKET_REIGN_UNLIVING_HC) && !hasCooldown(cooldown::REIGN_UNLIVING_HC)) {
+            // Open question: can NM reign proc a stack of the HM buff and vice versa?
+            if (hasTrinket(TRINKET_REIGN_UNLIVING_HC) && 
+                !hasCooldown(cooldown::REIGN_UNLIVING_HC) &&
+                instance.spell->id != spell::PILLAR_OF_FLAME_HC) {
                 if (buffStacks(buff::REIGN_UNLIVING_HC) == 2) {
                     actions.push_back(spellAction<spell::PillarOfFlameHc>(target));
                     actions.push_back(buffExpireAction<buff::ReignUnlivingHc>());
@@ -1123,7 +1126,9 @@ std::vector<action::Action> Player::onSpellImpactProc(const State& state, const 
                     actions.push_back(buffCooldownAction<buff::ReignUnlivingHc, cooldown::ReignUnlivingHc>());
                 }
             }
-            if (hasTrinket(TRINKET_REIGN_UNLIVING_NM) && !hasCooldown(cooldown::REIGN_UNLIVING_NM)) {
+            if (hasTrinket(TRINKET_REIGN_UNLIVING_NM) &&
+                !hasCooldown(cooldown::REIGN_UNLIVING_NM) &&
+                instance.spell->id != spell::PILLAR_OF_FLAME_NM) {
                 if (buffStacks(buff::REIGN_UNLIVING_NM) == 2) {
                     actions.push_back(spellAction<spell::PillarOfFlameNm>(target));
                     actions.push_back(buffExpireAction<buff::ReignUnlivingNm>());


### PR DESCRIPTION
According to [this](https://www.wowhead.com/wotlk/item=47188/reign-of-the-unliving#comments:id=839046) wowhead comment crits from Reign of the Unliving's proc do not generate additional charges.